### PR TITLE
Upgrade Grafana to 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ run	pip install --install-option="--prefix=/var/lib/graphite" --install-option="
 
 # grafana
 run     cd ~ &&\
-	wget https://grafanarel.s3.amazonaws.com/builds/grafana_2.6.0_amd64.deb &&\
-        dpkg -i grafana_2.6.0_amd64.deb && rm grafana_2.6.0_amd64.deb
+	wget https://grafanarel.s3.amazonaws.com/builds/grafana_3.0.1_amd64.deb &&\
+        dpkg -i grafana_3.0.1_amd64.deb && rm grafana_3.0.1_amd64.deb
 
 # statsd
 add	./statsd/config.js /src/statsd/config.js


### PR DESCRIPTION
This upgrades the version of Grafana used from 2.6 to 3.0 to take
advantage of the improvements to the UI, plugins and CLI tooling.

Changelog: https://github.com/grafana/grafana/blob/master/CHANGELOG.md