### PR TITLE
Disable basic auth in Grafana and support graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,5 @@ env STATSD_IPV6 0
 
 add ./bin/init /usr/bin/init
 
-cmd /usr/bin/init
+cmd exec /usr/bin/init
 

--- a/grafana/config.ini
+++ b/grafana/config.ini
@@ -67,6 +67,9 @@ org_name = Main Org.
 ; specify role for unauthenticated users
 org_role = Admin
 
+[auth.basic]
+enabled = false
+
 [log]
 ; Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Trace"
 level = Info


### PR DESCRIPTION
This fixes https://github.com/SamSaffron/graphite_docker/issues/16