### PR TITLE
Add graphite-web dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ run	apt-get -y install software-properties-common &&\
 run     apt-get -y install nodejs python-django-tagging python-simplejson python-memcache \
 			    python-ldap python-cairo python-django python-twisted   \
 			    python-pysqlite2 python-support python-pip gunicorn     \
-			    supervisor nginx-light nodejs git wget curl
+			    supervisor nginx-light nodejs git wget curl \
+			    python-dev libcairo2-dev libffi-dev build-essential
 
 # Install statsd
 run	mkdir /src && git clone https://github.com/etsy/statsd.git /src/statsd


### PR DESCRIPTION
Add the dependencies for graphite-web so that the docker build can
successfully install it.

Using the dependencies listed in the graphite-web documentation here: http://graphite.readthedocs.io/en/latest/install-pip.html

The current build results in:

```
Step 9/30 : RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/webapp" graphite-web
 ---> Running in 9fda6791bdb6
Downloading/unpacking graphite-web
  Running setup.py (path:/tmp/pip_build_root/graphite-web/setup.py) egg_info for package graphite-web

    warning: no files found matching '*' under directory 'distro/'
    warning: no files found matching '*.html' under directory 'webapp/graphite/'
    warning: no files found matching '*' under directory 'webapp/content/'
    warning: no previously-included files found matching 'webapp/graphite/local_settings.py'
    warning: no previously-included files found matching 'conf/*.conf'
Downloading/unpacking Django>=1.9,<1.9.99 (from graphite-web)
Downloading/unpacking django-tagging==0.4.3 (from graphite-web)
  Downloading django_tagging-0.4.3-py2.py3-none-any.whl
Requirement already satisfied (use --upgrade to upgrade): pytz in /usr/local/lib/python2.7/dist-packages (from graphite-web)
Downloading/unpacking pyparsing (from graphite-web)
Downloading/unpacking cairocffi (from graphite-web)
  Running setup.py (path:/tmp/pip_build_root/cairocffi/setup.py) egg_info for package cairocffi
    c/_cffi_backend.c:2:20: fatal error: Python.h: No such file or directory
     #include <Python.h>
                        ^
    compilation terminated.
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_root/cairocffi/setup.py", line 44, in <module>
        extras_require={'xcb': ['xcffib>=0.3.2']},
      File "/usr/lib/python2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 239, in __init__
        self.fetch_build_eggs(attrs.pop('setup_requires'))
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 264, in fetch_build_eggs
        replace_conflicting=True
      File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 620, in resolve
        dist = best[req.key] = env.best_match(req, ws, installer)
      File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 858, in best_match
        return self.obtain(req, installer) # try and download/install
      File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 870, in obtain
        return installer(requirement)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 314, in fetch_build_egg
        return cmd.easy_install(req)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 616, in easy_install
        return self.install_item(spec, dist.location, tmpdir, deps)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 646, in install_item
        dists = self.install_eggs(spec, download, tmpdir)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 834, in install_eggs
        return self.build_and_install(setup_script, setup_base)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1040, in build_and_install
        self.run_setup(setup_script, setup_base, args)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1028, in run_setup
        raise DistutilsError("Setup script exited with %s" % (v.args[0],))
    distutils.errors.DistutilsError: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    Complete output from command python setup.py egg_info:
    c/_cffi_backend.c:2:20: fatal error: Python.h: No such file or directory

 #include <Python.h>

                    ^

compilation terminated.

Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_root/cairocffi/setup.py", line 44, in <module>

    extras_require={'xcb': ['xcffib>=0.3.2']},

  File "/usr/lib/python2.7/distutils/core.py", line 111, in setup

    _setup_distribution = dist = klass(attrs)

  File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 239, in __init__

    self.fetch_build_eggs(attrs.pop('setup_requires'))

  File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 264, in fetch_build_eggs

    replace_conflicting=True

  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 620, in resolve

    dist = best[req.key] = env.best_match(req, ws, installer)

  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 858, in best_match

    return self.obtain(req, installer) # try and download/install

  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 870, in obtain

    return installer(requirement)

  File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 314, in fetch_build_egg

    return cmd.easy_install(req)

  File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 616, in easy_install

    return self.install_item(spec, dist.location, tmpdir, deps)

  File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 646, in install_item

    dists = self.install_eggs(spec, download, tmpdir)

  File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 834, in install_eggs

    return self.build_and_install(setup_script, setup_base)

  File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1040, in build_and_install

    self.run_setup(setup_script, setup_base, args)

  File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1028, in run_setup

    raise DistutilsError("Setup script exited with %s" % (v.args[0],))

distutils.errors.DistutilsError: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /tmp/pip_build_root/cairocffi
Storing debug log for failure in /root/.pip/pip.log
The command '/bin/sh -c pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/webapp" graphite-web' returned a non-zero code: 1
```